### PR TITLE
Updated blog post URL

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -42,7 +42,7 @@ Announcements
 .. _watch the talk:
    http://www.archive.org/details/Wednesday-203-6-IpythonANewArchitectureForInteractiveAndParallel
 .. _visual tour of the new features:
-   http://stronginference.com/weblog/2011/7/15/innovations-in-ipython.html
+   http://stronginference.com/innovations-in-ipython.html
 
 .. image:: _static/ipy_0.11.png
   


### PR DESCRIPTION
Just a correction to the URL for my blog post on iPython 0.11, which I moved to a different host.
