### PR TITLE
added links to the new build list

### DIFF
--- a/_templates/sidebar_links.html
+++ b/_templates/sidebar_links.html
@@ -9,7 +9,9 @@
         <a class="reference external" href="http://projects.scipy.org/mailman/listinfo/ipython-user">
             User</a> · 
         <a class="reference external" href="http://projects.scipy.org/mailman/listinfo/ipython-dev">
-            Dev</a>
+            Dev</a> ·
+        <a class="reference external" href="http://lists.ipython.org/listinfo.cgi/ipython-build-ipython.org">
+            Build</a>
         </li></span>
     <li><a class="reference external" href="http://webchat.freenode.net/?channels=ipython&uio=d4">
             IRC channel</a><br/>

--- a/developer.rst
+++ b/developer.rst
@@ -68,6 +68,12 @@ Our old `Trac site <http://projects.scipy.org/ipython/ipython>`_ contains a numb
 ========================
 
 We have a `mailing list <http://projects.scipy.org/mailman/listinfo/ipython-dev>`_ for discussions about the development of IPython.  There is also a web-based `gmane mirror <http://news.gmane.org/thread.php?group=gmane.comp.python.ipython.devel>`_ of this list.
+Additionally, as of 2012-02-22, there is now a `build mailing list
+<http://lists.ipython.org/listinfo.cgi/ipython-build-ipython.org>`_ which gets
+automatically generated messages from the IPython
+`continuous integration server <https://jenkins.shiningpanda.com/ipython/>`_
+whenever the tests fail, and with the first successful build after tests have
+been failing.
 
 =======================
  External Dependencies 


### PR DESCRIPTION
As discussed on the [mailing list](http://mail.scipy.org/pipermail/ipython-dev/2012-February/008801.html) - here are changes which include links to the new build mailing list which will be auto-populated by our CI server
