### PR TITLE
Add Anaconda to Install Instructions

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -14,17 +14,31 @@ basic libraries for scientific computing and data analysis.
 
 **Mac or Windows**
 
-1. Download and install the free edition of the `Enthought Python Distribution
+1. Download and install `Anaconda <http://continuum.io/downloads.html>`_ or the free edition of the `Enthought Python Distribution
 (EPD) <https://www.enthought.com/products/epd_free.php>`_.
 
 2. Update IPython to the current version:
 
 * On a Mac, using the Terminal application::
 
+  Anaconda::
+
+    conda update conda
+    conda update ipython
+
+  EPD::
+
     sudo enpkg enstaller
     sudo enpkg ipython
 
 * On Windows, at the Command Prompt (``cmd.exe`` application)::
+
+  Anaconda::
+
+    conda update conda
+    conda update ipython
+
+  EPD::
 
     enpkg enstaller
     enpkg ipython


### PR DESCRIPTION
The free Anaconda distribution is a great, easy way for someone to get IPython (and with the included package manager conda - easily update to the latest version of IPython). Added to the instructions so those who want to install IPython know about this option in addition to EPD for Mac & Windows.
