### PR TITLE
Quick Reference PDF link addition

### DIFF
--- a/documentation.rst
+++ b/documentation.rst
@@ -28,6 +28,7 @@ Other useful documentation
   given at various venues regarding IPython over the years.
 * `Videos and screencasts <videos.html>`_.
 * IPython `screenshots <screenshots/index.html>`_.
+* IPython quick referance card 'PDF <http://dl.dropboxusercontent.com/u/54552252/ipython-quickref.pdf>`_.
 * An `article about IPython
   <http://fperez.org/papers/ipython07_pe-gr_cise.pdf>`_, written by Fernando
   Perez and Brian Granger, published in the `May/June 2007 issue


### PR DESCRIPTION
Hello, 

I made the changes suggested by tookitook (not me) [here](http://www.reddit.com/r/IPython/comments/1dh81f/ipthon_quick_reference_pdf/c9qws56) on the IPython subreddit.  The [PDF](http://dl.dropboxusercontent.com/u/54552252/ipython-quickref.pdf) that is hosted on dropbox (not my pdf) was added as a link to the documentation page.  If you would prefer I can host the PDF in my dropbox but I thought that the original poster may make useful future revisions.
