### PR TITLE
Quick Reference link addition

### DIFF
--- a/documentation.rst
+++ b/documentation.rst
@@ -28,7 +28,7 @@ Other useful documentation
   given at various venues regarding IPython over the years.
 * `Videos and screencasts <videos.html>`_.
 * IPython `screenshots <screenshots/index.html>`_.
-* IPython quick referance card 'PDF <http://dl.dropboxusercontent.com/u/54552252/ipython-quickref.pdf>`_.
+* 'IPython quick referance card <http://damontallen.github.io/IPython-quick-ref-sheets/>`_.
 * An `article about IPython
   <http://fperez.org/papers/ipython07_pe-gr_cise.pdf>`_, written by Fernando
   Perez and Brian Granger, published in the `May/June 2007 issue


### PR DESCRIPTION
The addition of the link to quick reference svg images is based on the request in [this Reddit post](http://www.reddit.com/r/IPython/comments/1dh81f/ipthon_quick_reference_pdf/).  The quick reference text comes from the %quickref magic.
