### PR TITLE
Update of notebook.html

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-#h Makefile for building a website using sphinx.
+# Makefile for building a website using sphinx.
 # This Makefile has been heavily modified from the original that
 # sphinx-quickstart automatically creates
 

--- a/index.rst
+++ b/index.rst
@@ -1,7 +1,7 @@
 IPython provides a rich architecture for interactive computing with:
 
 - Powerful interactive shells (terminal and `Qt-based`_).
-- A browser-based notebook_ with support for code, text, mathematical
+- A browser-based notebook_ with support for code, rich text, mathematical
   expressions, inline plots and other rich media.
 - Support for interactive data visualization and use of `GUI toolkits`_.
 - Flexible, embeddable_ interpreters to load into your own projects.
@@ -10,6 +10,7 @@ IPython provides a rich architecture for interactive computing with:
 .. image:: _static/ipy_0.13.png
     :width: 400px
     :alt: IPython clients
+    :text-align: center
     :target: _static/ipy_0.13.png
 	   
 While the focus of the project is Python, our architecture is designed in a

--- a/install.rst
+++ b/install.rst
@@ -14,8 +14,9 @@ basic libraries for scientific computing and data analysis.
 
 **Mac or Windows**
 
-1. Download and install `Anaconda <http://continuum.io/downloads.html>`_ or the free edition of the `Enthought Python Distribution
-(EPD) <https://www.enthought.com/products/epd_free.php>`_.
+1. Download and install `Anaconda <http://continuum.io/downloads.html>`_ 
+or the free edition of the `Enthought Python Distribution (EPD) 
+<https://www.enthought.com/products/epd_free.php>`_.
 
 2. Update IPython to the current version:
 

--- a/notebook.rst
+++ b/notebook.rst
@@ -4,20 +4,31 @@
  The IPython Notebook
 ======================
 
-The IPython Notebook is a web-based interactive computational environment where
-you can combine code execution, text, mathematics, plots and rich media into a
-single document:
+The IPython Notebook is an interactive computational environment, in which
+you can combine code execution, rich text, mathematics, plots and rich media, and store the results in a persistent way. It aims to be an agile tool both for exploratory computation and data analysis, as well as reproducible research.
+
 
 .. image:: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
     :width: 350px
-    :alt: The IPython notebook with embedded text, code, math and figures.
+    :alt: The IPython notebook with embedded rich text, code, math and figures.
     :target: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
 
+The IPython Notebook combines together several pieces:
 
-These notebooks are normal files that can be shared with colleagues, converted
-to other formats such as HTML or PDF, etc.  You can share any publicly
+* The IPython Notebook web application
+	The dynamic IPython Notebook is a web application which runs in a web browser.
+
+
+* IPython notebook documents, which provide a persistent record of the calculations and results
+
+
+
+ Notebook documents, or notebooks,	 are standard text files that can be stored in version control systems and 
+ shared with colleagues. The results that they contain can be easily output to other static formats, such as HTML, PDF, and slide shows.
+
+You may share any publicly
 available notebook by using the `IPython Notebook Viewer
-<http://nbviewer.ipython.org>`_ service which will render it as a static web
+<http://nbviewer.ipython.org>`_ service, which will render it as a static web
 page. This makes it easy to give your colleagues a document they can read
 immediately without having to install anything.
 

--- a/notebook.rst
+++ b/notebook.rst
@@ -1,40 +1,91 @@
 .. _notebook:
    
-======================
- The IPython Notebook
-======================
+======================  The IPython Notebook ======================
 
-The IPython Notebook is an interactive computational environment, in which
-you can combine code execution, rich text, mathematics, plots and rich media, and store the results in a persistent way. It aims to be an agile tool both for exploratory computation and data analysis, as well as reproducible research.
-
-
-.. image:: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
-    :width: 350px
-    :alt: The IPython notebook with embedded rich text, code, math and figures.
-    :target: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
-
-The IPython Notebook combines together several pieces:
-
-* The IPython Notebook web application
-	The dynamic IPython Notebook is a web application which runs in a web browser.
+The IPython Notebook is an interactive computational environment, in which you
+can combine code execution, rich text, mathematics, plots and rich media,  and
+store the results in a persistent way. It aims to be an agile tool both  for
+exploratory computation and data analysis, as well as reproducible  research.
 
 
-* IPython notebook documents, which provide a persistent record of the calculations and results
+.. image:: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-
+ipython_proposal_fig_ipython-notebook-specgram.png     :width: 350px     :alt:
+The IPython notebook with embedded rich text, code, math and figures. :target:
+_static/sloangrant/9_home_fperez_prof_grants_1207-sloan-
+ipython_proposal_fig_ipython-notebook-specgram.png
+
+
+The IPython Notebook combines two components:
+
+* A web application, called the *IPython Notebook web app*, for interactive
+authoring of literate computations, in which explanatory text, mathematics,
+computations and rich media output may be combined. Input and output are
+stored in persistent cells that may be edited in-place.
+
+* Plain text documents, called *notebook documents*, or *notebooks*, for
+recording and distributing the results of the rich computations.
+
+
+The Notebook app automatically saves the current state of the computation in
+the web browser to the corresponding notebook, which is just a standard text
+file with the extension ``.ipynb``, stored in a working directory on your
+computer. This file can be easily put under version control and shared with
+colleagues.
+
+Despite the fact that the notebook documents are plain text files, they use
+the JSON format in order to store a *complete*, *reproducible* copy of the
+state of the computation as it is inside the Notebook app.
+
+Features of the IPython Notebook web app
+----------------------------------------
+
+Some of the main features of the IPython Notebook app include:
+
+* Display rich data representations (e.g. HTML / LaTeX / SVG) in the browser
+* as a result of computations. Compose text cells using Markdown and HTML.
+* Include mathematical equations, rendered directly in the browser by MathJax.
+* Import standard Python scripts In-browser editing, syntax highlighting, tab
+* completion and autoindentation. Inline figures rendered by the
+* ``matplotlib`` library with publication quality, in a range of formats (SVG
+* / PDF / PNG).
+
+If you have ever used the Mathematica or SAGE notebooks (the latter is also
+web- based__) you should feel right at home.  If you have not, you will be
+able to learn how to use the IPython Notebook in just a few minutes.
+
+.. __: http://sagenb.org
 
 
 
- Notebook documents, or notebooks,	 are standard text files that can be stored in version control systems and 
- shared with colleagues. The results that they contain can be easily output to other static formats, such as HTML, PDF, and slide shows.
 
-You may share any publicly
-available notebook by using the `IPython Notebook Viewer
-<http://nbviewer.ipython.org>`_ service, which will render it as a static web
-page. This makes it easy to give your colleagues a document they can read
-immediately without having to install anything.
+
+Notebook documents ------------------
+
+Notebook documents, or *notebooks*, are files which record all computations
+carried out and the results obtained in a literate way, including inputs,
+outputs, toegether with descriptive text and mathematics.
+
+They are plain text files, which are thus easy to share with colleagues and
+place under version control. But, by using the JSON format, they can record
+all aspects of the computation, including embedding rich media output. The
+standard file extension for notebook documents is ``.ipynb``.
+
+Notebooks may easily be exported to a range of static formats, including HTML
+(for example, for blog posts), PDF and slide shows. Furthermore, any publicly
+available notebook may be shared via the `IPython Notebook Viewer
+<http://nbviewer.ipython.org>`_ service, which will provide it as a static web
+page. The results may thus be shared without having to install anything.
+
+
+
+You may share any publicly available notebook by using the `IPython Notebook
+Viewer <http://nbviewer.ipython.org>`_ service, which will render it as a
+static web page. This makes it easy to give your colleagues a document they
+can read immediately without having to install anything.
 
 To learn more about using the IPython Notebook, you can visit our `example
-collection`_, and you can read the documentation_ for all the details on how to
-use and configure the system. The `Notebook Gallery`_ showcases many
+collection`_, and you can read the documentation_ for all the details on how
+to use and configure the system. The `Notebook Gallery`_ showcases many
 interesting notebooks covering a variety of topics, from basic programming to
 advanced scientific computing.
 
@@ -44,13 +95,17 @@ Here is a short demo of the notebook's basic features by the Pybonacci_ team:
 .. raw:: html
 
    <div align="center"> <iframe title="YouTube video player2" width="550"
-   height="350" src="http://www.youtube.com/embed/H6dLGQw9yFQ" frameborder="0"
-   allowfullscreen></iframe></div><br>
+height="350" src="http://www.youtube.com/embed/H6dLGQw9yFQ" frameborder="0"
+allowfullscreen></iframe></div><br>
 
 .. _Pybonacci: http://pybonacci.wordpress.com.
 
-.. _example collection: https://github.com/ipython/ipython/tree/master/examples/notebooks#a-collection-of-notebooks-for-using-ipython-effectively
+.. _example collection:
+.. https://github.com/ipython/ipython/tree/master/examples/notebooks#a
+.. -collection-of-notebooks-for-using-ipython-effectively
 
-.. _documentation: http://ipython.org/ipython-doc/stable/interactive/htmlnotebook.html
+.. _documentation: http://ipython.org/ipython-
+.. doc/stable/interactive/notebook.html
 
-.. _notebook gallery: https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks
+.. _notebook gallery: https://github.com/ipython/ipython/wiki/A-gallery-of-
+.. interesting-IPython-Notebooks

--- a/notebook.rst
+++ b/notebook.rst
@@ -1,29 +1,26 @@
 .. _notebook:
    
-======================  The IPython Notebook ======================
+======================  
+The IPython Notebook 
+======================
 
 The IPython Notebook is an interactive computational environment, in which you
 can combine code execution, rich text, mathematics, plots and rich media,  and
-store the results in a persistent way. It aims to be an agile tool both  for
-exploratory computation and data analysis, as well as reproducible  research.
+store the results in a persistent way. It aims to be an agile tool both for
+exploratory computation and data analysis, and for reproducible research.
 
 
-.. image:: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-
-ipython_proposal_fig_ipython-notebook-specgram.png     :width: 350px     :alt:
-The IPython notebook with embedded rich text, code, math and figures. :target:
-_static/sloangrant/9_home_fperez_prof_grants_1207-sloan-
-ipython_proposal_fig_ipython-notebook-specgram.png
+.. image:: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
+	 :width: 350px  
+	 :alt: The IPython notebook with embedded rich text, code, mathematics and figures. 
+	 :target: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
 
 
 The IPython Notebook combines two components:
 
-* A web application, called the *IPython Notebook web app*, for interactive
-authoring of literate computations, in which explanatory text, mathematics,
-computations and rich media output may be combined. Input and output are
-stored in persistent cells that may be edited in-place.
+* A web application, called the *IPython Notebook web app*, for interactive authoring of literate computations, in which explanatory text, mathematics,computations and rich media output may be combined. Input and output are stored in persistent cells that may be edited in-place.
 
-* Plain text documents, called *notebook documents*, or *notebooks*, for
-recording and distributing the results of the rich computations.
+* Plain text documents, called *notebook documents*, or *notebooks*, for recording and distributing the results of the rich computations.
 
 
 The Notebook app automatically saves the current state of the computation in
@@ -41,25 +38,24 @@ Features of the IPython Notebook web app
 
 Some of the main features of the IPython Notebook app include:
 
-* Display rich data representations (e.g. HTML / LaTeX / SVG) in the browser
-* as a result of computations. Compose text cells using Markdown and HTML.
+* Display rich data representations (e.g. HTML / LaTeX / SVG) in the browser as a result of computations. 
+* Compose rich text using Markdown and HTML.
 * Include mathematical equations, rendered directly in the browser by MathJax.
-* Import standard Python scripts In-browser editing, syntax highlighting, tab
-* completion and autoindentation. Inline figures rendered by the
-* ``matplotlib`` library with publication quality, in a range of formats (SVG
-* / PDF / PNG).
+* Import standard Python scripts.
+* In-browser editing, syntax highlighting, tab completion and autoindentation. 
+* Inline figures rendered by the matplotlib_ library with publication quality, in a range of formats (SVG / PDF / PNG).
+
+.. _matplotlib: http://matplotlib.org
 
 If you have ever used the Mathematica or SAGE notebooks (the latter is also
-web- based__) you should feel right at home.  If you have not, you will be
+web-based__) you should feel right at home.  If you have not, you will be
 able to learn how to use the IPython Notebook in just a few minutes.
 
 .. __: http://sagenb.org
 
 
-
-
-
-Notebook documents ------------------
+Notebook documents 
+------------------
 
 Notebook documents, or *notebooks*, are files which record all computations
 carried out and the results obtained in a literate way, including inputs,
@@ -71,41 +67,55 @@ all aspects of the computation, including embedding rich media output. The
 standard file extension for notebook documents is ``.ipynb``.
 
 Notebooks may easily be exported to a range of static formats, including HTML
-(for example, for blog posts), PDF and slide shows. Furthermore, any publicly
+(for example, for blog posts), PDF and slide shows. Any publicly
 available notebook may be shared via the `IPython Notebook Viewer
 <http://nbviewer.ipython.org>`_ service, which will provide it as a static web
-page. The results may thus be shared without having to install anything.
-
-
-
-You may share any publicly available notebook by using the `IPython Notebook
-Viewer <http://nbviewer.ipython.org>`_ service, which will render it as a
-static web page. This makes it easy to give your colleagues a document they
+page. This makes it easy to give your colleagues a document they
 can read immediately without having to install anything.
+
 
 To learn more about using the IPython Notebook, you can visit our `example
 collection`_, and you can read the documentation_ for all the details on how
-to use and configure the system. The `Notebook Gallery`_ showcases many
+to use and configure the system. The `notebook gallery`_ showcases many
 interesting notebooks covering a variety of topics, from basic programming to
 advanced scientific computing.
 
-
-Here is a short demo of the notebook's basic features by the Pybonacci_ team:
+Here is a short demo of the IPython Notebook's basic features by the
+Pybonacci_ team:
 
 .. raw:: html
 
-   <div align="center"> <iframe title="YouTube video player2" width="550"
-height="350" src="http://www.youtube.com/embed/H6dLGQw9yFQ" frameborder="0"
-allowfullscreen></iframe></div><br>
+   <div align="center"> 
+   <iframe title="YouTube video player2" 
+   width="550" height="350" 
+   src="http://www.youtube.com/embed/H6dLGQw9yFQ" 
+   frameborder="0" allowfullscreen>
+   </iframe></div><br>
 
 .. _Pybonacci: http://pybonacci.wordpress.com.
 
-.. _example collection:
-.. https://github.com/ipython/ipython/tree/master/examples/notebooks#a
-.. -collection-of-notebooks-for-using-ipython-effectively
+.. _example collection: 
+		https://github.com/ipython/ipython/tree/master/examples/notebooks#a-collection-of-notebooks-for-using-ipython-effectively
 
-.. _documentation: http://ipython.org/ipython-
-.. doc/stable/interactive/notebook.html
+.. _documentation: http://ipython.org/ipython-doc/stable/interactive/notebook.html
 
-.. _notebook gallery: https://github.com/ipython/ipython/wiki/A-gallery-of-
-.. interesting-IPython-Notebooks
+.. _notebook gallery: 
+		https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks
+
+For a thorough introduction to the IPython Notebook, you can check out the
+*IPython in Depth* tutorial from the SciPy_ 2013 scientific Python conference, 
+which was given by the two founders of the IPython package:
+
+.. raw:: html
+
+   <div align="center"> 
+   <iframe title="YouTube video player3"
+   <iframe width="560" height="315" 
+   src="http://www.youtube.com/embed/xe_ATRmw0KM" frameborder="0" 
+   allowfullscreen></iframe>
+   </div><br>
+
+
+.. _SciPy: 
+.. https://conference.scipy.org/scipy2013/
+

--- a/notebook.rst
+++ b/notebook.rst
@@ -5,10 +5,8 @@ The IPython Notebook
 ======================
 
 The IPython Notebook is an interactive computational environment, in which you
-can combine code execution, rich text, mathematics, plots and rich media,  and
-store the results in a persistent way. It aims to be an agile tool both for
-exploratory computation and data analysis, and for reproducible research.
-
+can combine code execution, rich text, mathematics, plots and rich media, as
+shown in this example session:
 
 .. image:: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
 	 :width: 350px  
@@ -16,11 +14,16 @@ exploratory computation and data analysis, and for reproducible research.
 	 :target: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
 
 
-The IPython Notebook combines two components:
+It aims to be an agile tool for both exploratory computation and data analysis, 
+and provides a platform to support **reproducible research**, since all inputs 
+and outputs may be stored in a one-to-one way in notebook documents.
 
-* A web application, called the *IPython Notebook web app*, for interactive authoring of literate computations, in which explanatory text, mathematics,computations and rich media output may be combined. Input and output are stored in persistent cells that may be edited in-place.
 
-* Plain text documents, called *notebook documents*, or *notebooks*, for recording and distributing the results of the rich computations.
+There are two components:
+
+* The **IPython Notebook** web application, for interactive authoring of literate computations, in which explanatory text, mathematics, computations and rich media output may be combined. Input and output are stored in persistent cells that may be edited in-place.
+
+* Plain text documents, called **notebooks**, for recording and distributing the results of the rich computations.
 
 
 The Notebook app automatically saves the current state of the computation in
@@ -30,8 +33,8 @@ computer. This file can be easily put under version control and shared with
 colleagues.
 
 Despite the fact that the notebook documents are plain text files, they use
-the JSON format in order to store a *complete*, *reproducible* copy of the
-state of the computation as it is inside the Notebook app.
+the JSON format in order to store a **complete**, **reproducible** copy of the
+current state of the computation inside the Notebook app.
 
 Features of the IPython Notebook web app
 ----------------------------------------
@@ -39,13 +42,15 @@ Features of the IPython Notebook web app
 Some of the main features of the IPython Notebook app include:
 
 * Display rich data representations (e.g. HTML / LaTeX / SVG) in the browser as a result of computations. 
-* Compose rich text using Markdown and HTML.
-* Include mathematical equations, rendered directly in the browser by MathJax.
+* Compose rich text using Markdown_ and HTML.
+* Include mathematical equations, rendered directly in the browser by MathJax_.
 * Import standard Python scripts.
 * In-browser editing, syntax highlighting, tab completion and autoindentation. 
 * Inline figures rendered by the matplotlib_ library with publication quality, in a range of formats (SVG / PDF / PNG).
 
 .. _matplotlib: http://matplotlib.org
+.. _Markdown: http://daringfireball.net/projects/markdown/syntax
+.. _MathJax: http://mathjax.org
 
 If you have ever used the Mathematica or SAGE notebooks (the latter is also
 web-based__) you should feel right at home.  If you have not, you will be
@@ -57,7 +62,7 @@ able to learn how to use the IPython Notebook in just a few minutes.
 Notebook documents 
 ------------------
 
-Notebook documents, or *notebooks*, are files which record all computations
+Notebook documents (or notebooks) are files which record all computations
 carried out and the results obtained in a literate way, including inputs,
 outputs, toegether with descriptive text and mathematics.
 
@@ -66,7 +71,7 @@ place under version control. But, by using the JSON format, they can record
 all aspects of the computation, including embedding rich media output. The
 standard file extension for notebook documents is ``.ipynb``.
 
-Notebooks may easily be exported to a range of static formats, including HTML
+Notebooks may easily be exported_ to a range of static formats, including HTML
 (for example, for blog posts), PDF and slide shows. Any publicly
 available notebook may be shared via the `IPython Notebook Viewer
 <http://nbviewer.ipython.org>`_ service, which will provide it as a static web
@@ -99,12 +104,15 @@ Pybonacci_ team:
 
 .. _documentation: http://ipython.org/ipython-doc/stable/interactive/notebook.html
 
+.. _exported: http://ipython.org/ipython-doc/stable/interactive/nbconvert.html
+
 .. _notebook gallery: 
 		https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks
 
 For a thorough introduction to the IPython Notebook, you can check out the
-*IPython in Depth* tutorial from the SciPy_ 2013 scientific Python conference, 
-which was given by the two founders of the IPython package:
+*IPython in Depth* tutorial from the `SciPy 2013`_ scientific Python 
+conference, led by the two creators of the IPython package, Fernando Pérez
+and Brian Granger:
 
 .. raw:: html
 
@@ -116,6 +124,6 @@ which was given by the two founders of the IPython package:
    </div><br>
 
 
-.. _SciPy: 
+.. _SciPy 2013: 
 .. https://conference.scipy.org/scipy2013/
 

--- a/notebook.rst
+++ b/notebook.rst
@@ -8,11 +8,18 @@ The IPython Notebook is an interactive computational environment, in which you
 can combine code execution, rich text, mathematics, plots and rich media, as
 shown in this example session:
 
+.. raw:: html
+
+   <div align="center">
+
 .. image:: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
 	 :width: 350px  
 	 :alt: The IPython notebook with embedded rich text, code, mathematics and figures. 
 	 :target: _static/sloangrant/9_home_fperez_prof_grants_1207-sloan-ipython_proposal_fig_ipython-notebook-specgram.png
 
+.. raw:: html
+
+   </div>
 
 It aims to be an agile tool for both exploratory computation and data analysis, 
 and provides a platform to support **reproducible research**, since all inputs 


### PR DESCRIPTION
Goes together with the refactor https://github.com/ipython/ipython/pull/3772 of the actual notebook docs.
I changed the name of the linked file there to notebook.html, so changed it here too.

I took the opportunity to add a link to the IPython in Depth tutorial from SciPy 2013.
