### PR TITLE
Fix usage of enpkg on OSX and windows

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -29,8 +29,7 @@ free edition of `Enthought Canopy
 
   Enthought Canopy::
 
-    sudo enpkg enstaller
-    sudo enpkg ipython
+    enpkg ipython
 
 * On Windows, at the Command Prompt (``cmd.exe`` application):
 
@@ -41,7 +40,6 @@ free edition of `Enthought Canopy
 
   Enthought Canopy::
 
-    enpkg enstaller
     enpkg ipython
 
 **Linux**


### PR DESCRIPTION
- With Canopy installs, it is no longer necessary to use `sudo` to install packages using `enpkg`. 
- `enpkg` prompts for enstaller updates by itself; it is not necessary to run an update for it, before installing packages.

@jdmarch, do you have any comments on this?  Thanks!
