### PR TITLE
Fix broken link for "example collection" 

### DIFF
--- a/notebook.rst
+++ b/notebook.rst
@@ -38,7 +38,7 @@ Here is a short demo of the notebook's basic features by the Pybonacci_ team:
 
 .. _Pybonacci: http://pybonacci.wordpress.com
 
-.. _example collection: https://github.com/ipython/ipython/tree/master/examples/Notebook
+.. _example collection: http://nbviewer.ipython.org/github/ipython/ipython/blob/2.x/examples/Notebook/Index.ipynb
 
 .. _documentation: http://ipython.org/ipython-doc/stable/interactive/htmlnotebook.html
 


### PR DESCRIPTION
The link is located at the bottom of notebook home page.
