### PR TITLE
Updated Enthought links.

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -25,7 +25,7 @@ basic libraries for scientific computing and data analysis.
 
 1. Download and install `Anaconda <http://continuum.io/downloads.html>`_ or the
 free edition of `Enthought Canopy
-<https://www.enthought.com/products/epd_free.php>`_.
+<https://www.enthought.com/downloads/>`_.
 
 2. Update IPython to the current version, using the Terminal/Command Prompt:
 

--- a/links.txt
+++ b/links.txt
@@ -26,8 +26,8 @@
 .. Other organizations
 .. _Alfred P. Sloan Foundation: http://www.sloan.org
 .. _Enthought inc:
-.. _Enthought: http://www.enthought.co
-.. _Enthought Python Distribution: http://www.enthought.com/products/epd.php
+.. _Enthought: http://www.enthought.com
+.. _Enthought Canopy: http://www.enthought.com/products/canopy/
 .. _numfocus: http://numfocus.org
 .. _HPCMP: http://www.hpcmo.hpc.mil
 .. _ERDC: http://www.erdc.usace.army.mil

--- a/sponsors.rst
+++ b/sponsors.rst
@@ -55,7 +55,7 @@ following sources:
 - `Enthought Inc`_ has supported IPython since its beginning in multiple forms,
   including --but not limited to-- the funding of our Qt console, hosting our
   website for many years, the continued hosting of our mailing lists, and the
-  inclusion of IPython in the `Enthought Python Distribution`_.
+  inclusion of IPython in `Enthought Canopy`_.
 
 - NiPy_/NIH: funding via the NiPy project (NIH grant 5R01MH081909-02) supported
   our 2009 refactoring work.


### PR DESCRIPTION
This PR updates some of the links to Enthought webpages.

It includes a typo fix, and adjustments to download links to reference Enthought Canopy instead of EPD.
In particular, it includes all of the changes which I suggested in:
https://github.com/ipython/ipython/issues/5899
https://github.com/ipython/ipython-website/pull/53
