### PR TITLE
Fix instructions for installing notebook dependencies on zsh/tcsh

### DIFF
--- a/install.rst
+++ b/install.rst
@@ -16,7 +16,7 @@ If you already have Python installed and are familiar with installing packages, 
 
 Or if you want to also get the dependencies for the IPython notebook::
 
-    pip install ipython[notebook]
+    pip install "ipython[notebook]"
 
 I am getting started with Python
 --------------------------------


### PR DESCRIPTION
As we talked about few hours ago (https://github.com/ipython/ipython/issues/6561#issuecomment-57060979). Using quotes make this work at least on bash, csh, zsh, sh, tcsh.
