### PR TITLE
Add some talks

### DIFF
--- a/videos.rst
+++ b/videos.rst
@@ -115,3 +115,45 @@ More videos and screencasts
 * A set `of 4 videos
   <http://showmedo.com/videos/series?name=PythonIPythonSeries>`_ by Ian Ozsvald
   showing various aspects of IPython. Created 2006.
+
+Chronological List of Talks and Tutorial recording
+==================================================
+
+Talks
+-----
+
+2014
+~~~~
+
+Fernando, PyCon APAC: `<https://www.youtube.com/watch?v=ZD5n9s8PGtI>`_
+Fernando, PyCon: `<https://www.youtube.com/watch?v=2NSbuKFYyvc>`_
+Min, PyData: `<https://www.youtube.com/watch?v=6JL-H2_xDLo>`_
+Thomas & Matthias, EuroSciPy : `<https://www.youtube.com/watch?v=brgMEWT1pYc>`_ 
+
+2013
+~~~~
+Fernando, PyData: `<http://vimeo.com/63250251>`_
+Brian, PyData NYC: `<http://vimeo.com/79832657>`_
+Fernando, SciPy: `<https://www.youtube.com/watch?v=j9YpkSX7NNM>`_
+
+2012
+~~~~
+Min, PyData, `<http://vimeo.com/63262448>`_
+Brian, PyData NYC, Bis `<http://vimeo.com/53056634>`_
+Brian, PyData NYC `<http://vimeo.com/53051817>`_
+
+
+Tutorial
+-------
+
+2014
+~~~
+Min, SciPy: `<http://www.youtube.com/watch?v=y4hgalfhc1Y>`_
+Fernando, Pycon: `<https://www.youtube.com/watch?v=XFw1JVXKJss>`_
+Brian, PyData: `<https://www.youtube.com/watch?v=VaV10VNZCLA>`_
+
+
+2013
+~~~
+Fernando, Pycon `<https://www.youtube.com/watch?v=bP8ydKBCZiY>`_
+


### PR DESCRIPTION
I did a talks yesterday in France to present IPython, and was asked wether or not there was a list of "recent" video for people who could not attend. So I think  we could just make a list on the website. 
I propose a simple rule: talks only from the core members, by reverse chronological order, who/which conference and link to keep the maintaining minimal.