### PR TITLE
revert auto pushing pages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ after_success:
     ssh-add .travis/travis_id_rsa_2048
     cd gh-pages
     # git push ghpages
+    git push ghpages master:test-deploy
   else
     echo "Will only deploy docs build from ipython-website master branch"
   fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ after_success:
     chmod 600 .travis/travis_id_rsa_2048
     ssh-add .travis/travis_id_rsa_2048
     cd gh-pages
-    git push ghpages
+    # git push ghpages
   else
     echo "Will only deploy docs build from ipython-website master branch"
   fi

--- a/_scripts/copy_trees.py
+++ b/_scripts/copy_trees.py
@@ -98,7 +98,7 @@ def main():
             print('top-level dirs:', dirs)
             #continue
 
-        files = filter(keep_filename, files)
+        files = list(filter(keep_filename, files))
         print('  dirs:', dirs)
         print('   files:', files)
         # Now, create the list of subdirs and files in the output


### PR DESCRIPTION
For some reason the copy-tree step on travis does not copy `CNAME`, `README.md` and `google46f5e5c36b67754a.html` into target dir which break the website. 