### PR TITLE
re-enable push to production

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,8 +25,7 @@ after_success:
     chmod 600 .travis/travis_id_rsa_2048
     ssh-add .travis/travis_id_rsa_2048
     cd gh-pages
-    # git push ghpages
-    git push ghpages master:test-deploy
+    git push ghpages
   else
     echo "Will only deploy docs build from ipython-website master branch"
   fi


### PR DESCRIPTION
Travis does not throw the [CNAME](https://github.com/ipython/ipython.github.com/blob/test-deploy/CNAME) file anymore.

So we can probably reenable deploying directly to production and not have ipython.org down. 