### PR TITLE
Discuss Jupyter / IPython

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -66,6 +66,23 @@ project <citing>`.
 IPython supports Python 2.7 and 3.3 or newer. Our older 1.x series supports
 Python 2.6 and 3.2.
 
+
+Jupyter and the future of IPython
+=================================
+
+IPython is a growing project, with increasingly language-agnostic components.
+IPython 3.0 will be the last monolithic release of IPython,
+containing the notebook server, qtconsole, etc. The language-agnostic parts of the project:
+the notebook format, message protocol, qtconsole, notebook web application, etc.
+will move to new projects under the name Jupyter_.
+IPython itself will return to being focused on interactive Python,
+part of which will be providing a Python kernel for Jupyter.
+IPython 3.0 contains some indications of the project transition,
+including the logo in the notebook web UI being that of Jupyter.
+
+.. _Jupyter: https://jupyter.org
+
+
 Announcements
 =============
 


### PR DESCRIPTION
adds a paragraph to the front page about Jupyter

ping @ellisonbg, @fperez

I'm not sure if we want this to be more prominent by putting it higher up the page, or reorganizing the content of the page more significantly to express the IPython/Jupyter components.

For now, this just adds a section with a paragraph discussing IPython/Jupyter above announcements,
which doesn't help our wall-of-text situation one bit.