### PR TITLE
Remove the ipython help chat room from the sidebar

### DIFF
--- a/_templates/sidebar_links.html
+++ b/_templates/sidebar_links.html
@@ -18,8 +18,6 @@ Share your notebooks
 <h3>{{ _('Community') }}</h3>
 
   <ul class="simple">
-    <li><a class="reference external" href="https://gitter.im/ipython/ipython/help">
-            Help Chat Room</a></li>
     <li><a class="reference external" href="http://stackoverflow.com/questions/tagged/ipython">
             Stack Overflow</a></li>
     <li><a class="reference external" href="http://projects.scipy.org/mailman/listinfo/ipython-dev">

--- a/_templates/sidebar_links.html
+++ b/_templates/sidebar_links.html
@@ -22,11 +22,10 @@ Share your notebooks
             Stack Overflow</a></li>
     <li><a class="reference external" href="http://projects.scipy.org/mailman/listinfo/ipython-dev">
             Mailing list</a></li>
-    <li><a class="reference external" href="https://github.com/ipython/ipython/wiki">Wiki</a></li>
-    <li><a class="reference external" href="http://www.reddit.com/r/IPython">
-            Reddit</a></li>
     <li><a class="reference external" href="https://github.com/ipython/ipython/issues">
             File a bug</a></li>
+    <li><a class="reference external" href="http://www.reddit.com/r/IPython">
+            Reddit</a></li>
   </ul>
 
 <div style="margin-top:10px">  <!-- sharing buttons -->
@@ -73,6 +72,7 @@ style="margin-bottom: 10px;"></a>
     href="https://github.com/ipython/ipython/wiki/Dev:-Index">Development information</a></li>
     <li><a class="reference external" href="http://travis-ci.org/#!/ipython/ipython">
         Travis CI</a></li>
+    <li><a class="reference external" href="https://github.com/ipython/ipython/wiki">Wiki</a></li>
   </ul>          
 </div>
 


### PR DESCRIPTION
We have decided to deemphasize the ipython/help chat room.