### PR TITLE
Replace PayPal buttons with Flipcause buttons

### DIFF
--- a/_templates/donate_button.html
+++ b/_templates/donate_button.html
@@ -1,7 +1,20 @@
-    <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
-    <input type="hidden" name="cmd" value="_s-xclick">
-    <input type="hidden" name="hosted_button_id" value="SMCAHLP2ST42G">
-    <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-    <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-    </form>
-    
+<!--This relies on some CSS & JS which is added in the _templates folder-->
+<div style="background: #34677c;
+    border-radius:0px 0px 0px 0px;
+    font-weight:normal;
+    font-family:Arial, Helvetica, sans-serif;
+    border:none;
+    box-shadow:none;
+    left: 50%;
+    margin-left:-72.5px; margin-top: 1em; margin-bottom: 1em;
+    clear: both; display: block;
+    width:145px; height:45px;
+    line-height:2.8;
+    position:relative;
+    font-size:16px;
+    text-align:center;
+    cursor:pointer;
+    color:#fff;
+    text-decoration: none;
+    z-index:1"
+  onclick="open_window('MjI1Ng==')">Donate Now</div>

--- a/_templates/sidebar_links.html
+++ b/_templates/sidebar_links.html
@@ -81,9 +81,7 @@ style="margin-bottom: 10px;"></a>
   <div class="tile" id="donate">
     <h4>Support IPython</h4>
 
-    <center>
     {% include "donate_button.html" %}
-    </center>
     <a href="{{pathto('donate')}}">Find out more...</a>
 
   </div>

--- a/donate.rst
+++ b/donate.rst
@@ -14,14 +14,27 @@ resources.  Any amount helps!
 
 .. raw:: html
 
-    <div class="tile" id="donate" align="center" style="margin:20px">
-    <form action="https://www.paypal.com/cgi-bin/webscr" method="post">
-    <input type="hidden" name="cmd" value="_s-xclick">
-    <input type="hidden" name="hosted_button_id" value="SMCAHLP2ST42G">
-    <input type="image" src="https://www.paypalobjects.com/en_US/i/btn/btn_donateCC_LG.gif" border="0" name="submit" alt="PayPal - The safer, easier way to pay online!">
-    <img alt="" border="0" src="https://www.paypalobjects.com/en_US/i/scr/pixel.gif" width="1" height="1">
-    </form>
-    </div>
+    <!--This relies on some CSS & JS which is added in the _templates folder-->
+    <div style="background: #34677c;
+        border-radius:0px 0px 0px 0px;
+        font-weight:normal;
+        font-family:Arial, Helvetica, sans-serif;
+        border:none;
+        box-shadow:none;
+        left: 50%;
+        margin-left:-72.5px; margin-top: 1em; margin-bottom: 1em;
+        display: block;
+        width:145px; height:45px;
+        line-height:2.8;
+        position:relative;
+        font-size:16px;
+        text-align:center;
+        cursor:pointer;
+        color:#fff;
+        text-decoration: none;
+        z-index:1"
+      onclick="open_window('MjI1Ng==')">Donate Now</div>
+
 
 
 All donations will be used strictly to fund IPython development, by supporting

--- a/themes/agogo/layout.html
+++ b/themes/agogo/layout.html
@@ -13,9 +13,59 @@
 {% extends "basic/layout.html" %}
 
 {# IPython-specific block #}
-{% set css_files = css_files + ["_static/ipython.css"] %}
+{% set css_files = css_files + ["_static/ipython.css", "_static/flipcause.css"] %}
 
 {% block header %}
+    <!-- Flipcause integration: -->
+    <script>
+    function open_window(cause_id) {
+      var protocol=String(document.location.protocol);
+      var new_url;
+      if( /Android|webOS|iPhone|iPad|iPod|BlackBerry|IEMobile|Opera Mini/i.test(navigator.userAgent)){
+        new_url="https://www.flipcause.com/widget/"+cause_id
+        window.open(new_url);
+      }
+      else {
+        document.getElementById("fc-fade").style.display="block";
+        document.getElementById("fc-fade").style.webkitAnimation="backfadesin 1s";
+        document.getElementById("fc-fade").style.animation="backfadesin 1s";
+        document.getElementById("fc-fade").style.mozAnimation="backfadesin 1s";
+        document.getElementById("fc-light").style.display="block";
+        document.getElementById("fc-light").style.webkitAnimation="fadesin 1.5s";
+        document.getElementById("fc-light").style.animation="fadesin 1.5s";
+        document.getElementById("fc-light").style.mozAnimation="fadesin 1.5s";
+        document.getElementById("fc-main").style.display="block";
+        document.getElementById("fc-main").style.webkitAnimation="fadesin 1.5s";
+        document.getElementById("fc-main").style.animation="fadesin 1.5s";
+        document.getElementById("fc-main").style.mozAnimation="fadesin 1.5s";
+        document.getElementById("fc-close").style.display="block";
+        document.getElementById("fc-close").style.webkitAnimation="fadesin 1.5s";
+        document.getElementById("fc-close").style.animation="fadesin 1.5s";
+        document.getElementById("fc-close").style.mozAnimation="fadesin 1.5s";
+        document.getElementById("fc-myFrame").style.display="block";
+        document.getElementById("fc-myFrame").style.webkitAnimation="fadesin 1.5s";
+        document.getElementById("fc-myFrame").style.animation="fadesin 1.5s";
+        document.getElementById("fc-myFrame").style.mozAnimation="fadesin 1.5s";
+        document.getElementById("fc-myFrame").src="https://www.flipcause.com/widget/"+cause_id;
+      }
+    }
+    function close_window() {
+      document.getElementById("fc-fade").style.display="none";
+      document.getElementById("fc-light").style.display="none";
+      document.getElementById("fc-main").style.display="none";
+      document.getElementById("fc-close").style.display="none";
+      document.getElementById("fc-myFrame").style.display="none";
+    }
+    </script>
+    <div id="fc-fade" class="fc-black_overlay" onclick="close_window()"></div>
+    <div id="fc-light" class="fc-white_content">
+     <div id="fc-main" class="fc-main-box">
+      <div id="fc-close" class="fc-widget_close" onclick="close_window()"></div>
+      <iframe id="fc-myFrame" iframe height="580" width="925" style="border: 0; border-radius:5px 5px 5px 5px; box-shadow:0 0 8px rgba(0, 0, 0, 0.5);" scrolling="no" src=""></iframe>
+     </div>
+    </div>
+    <!-- /flipcause -->
+
     <div class="header-wrapper">
       <div class="header">
         {%- block headertitle %}

--- a/themes/agogo/static/flipcause.css
+++ b/themes/agogo/static/flipcause.css
@@ -1,0 +1,68 @@
+.fc-black_overlay{ 
+display:none; position: fixed; z-index:1000001; top: 0%;left: 0%;width: 100%;height: 100%;
+background-color: black; filter: alpha(opacity=50); cursor:pointer; opacity:0.5; 
+}
+.fc-white_content {
+opacity:1; display:none; margin-top: -320px; margin-left: -485px; width:970px; height:640px; 
+position:fixed; top:50%; left:50%; border: none;z-index:1000002;overflow: auto;
+}
+.fc-main-box{
+opacity:1; display:none; margin:15px auto 0 auto; width:930px; position:relative; z-index:1000003;
+}
+.fc-widget_close{
+opacity:1; content:url(http://i1338.photobucket.com/albums/o691/WeCause/X_zpse4a7e538.png); 
+position:absolute; z-index=1000004; right:-16px; top:-16px; display:block; cursor:pointer; 
+}
+.floating_button{
+display: block; margin-top: 0px; margin-left: 0px; width:auto ; height: auto; 
+position:fixed; z-index:999999; overflow: auto;
+}
+@keyframes backfadesin {
+   from { opacity:0; }
+   to {opacity:.5;}
+}
+@-moz-keyframes backfadesin { 
+    from { opacity:0; }
+    to {opacity:.5;}
+}
+@-webkit-keyframes backfadesin { 
+    from { opacity:0; }
+    to {opacity:.5;}
+}
+@-o-keyframes backfadesin {
+    from { opacity:0; }
+    to {opacity:.5;}
+}
+@-ms-keyframes backfadesin {
+    from { opacity:0; }
+    to {opacity:.5;}
+}
+@keyframes fadesin {
+   0%{ opacity:0; }
+   50%{ opacity:0; }
+   75% {opacity: 0; transform: translateY(20px);}
+   100% {opacity: 1; transform: translateY(0);}
+}
+@-moz-keyframes fadesin {
+   0%{ opacity:0; }
+   50%{ opacity:0; }
+   75% {opacity: 0; -moz-transform: translateY(20px);}
+   100% {opacity: 1; -moz-transform: translateY(0);}
+}
+@-webkit-keyframes fadesin {
+   0%{ opacity:0; }
+   50%{ opacity:0; }
+   75% {opacity: 0; -webkit-transform: translateY(20px);}
+   100% {opacity: 1; -webkit-transform: translateY(0);}
+@-o-keyframes fadesin {
+   0%{ opacity:0; }
+   50%{ opacity:0; }
+   75% {opacity: 0; -o-transform: translateY(20px);}
+   100% {opacity: 1; -o-transform: translateY(0);}
+}
+@-ms-keyframes fadesin {
+   0%{ opacity:0; }
+   50%{ opacity:0; }
+   75% {opacity: 0; -ms-transform: translateY(20px);}
+   100% {opacity: 1; -ms-transform: translateY(0);}
+}


### PR DESCRIPTION
As requested by NumFocus.

Closes gh-108

Here's what they look like:

![screenshot from 2016-02-17 13 00 51](https://cloud.githubusercontent.com/assets/327925/13110232/99330cda-d576-11e5-8ea6-489157d2424c.png)
![screenshot from 2016-02-17 13 01 10](https://cloud.githubusercontent.com/assets/327925/13110233/994f1ca4-d576-11e5-8609-01fabf24bbad.png)

But do we think we can persuade Flipcause to get rid of this bit of stupidity in the popup:

![screenshot from 2016-02-17 13 02 05](https://cloud.githubusercontent.com/assets/327925/13110254/baedd2ec-d576-11e5-930a-e5a4bf4323bd.png)

Padlock signs within webpages mislead users about the padlock as a reliable sign of security, and I'd really like us not to be part of that problem.