### PR TITLE
Replace deprecated readthedocs.org domain with readthedocs.io

### DIFF
--- a/_templates/navbar.html
+++ b/_templates/navbar.html
@@ -1,4 +1,4 @@
-<a href="http://jupyter.readthedocs.org/en/latest/install.html" target="_blank">Install</a> · 
+<a href="http://jupyter.readthedocs.io/en/latest/install.html" target="_blank">Install</a> · 
 <a href="{{pathto('documentation')}}">Documentation</a> ·
 <a href="{{pathto('project')}}">Project</a> ·
 <a href="http://jupyter.org/" target="_blank">Jupyter</a> · 

--- a/documentation.rst
+++ b/documentation.rst
@@ -7,16 +7,16 @@ Current Documentation
 
 IPython is developed as a set of Subprojects under the larger `Project Jupyter
 <http://jupyter.org>`_ umbrella. The documentation of each Subproject is now
-being hosted using the `Read the Docs <https://readthedocs.org/>`_ service:
+being hosted using the `Read the Docs <https://readthedocs.io/>`_ service:
 
-* `IPython <http://ipython.readthedocs.org/en/stable/>`_: documentation for the
+* `IPython <http://ipython.readthedocs.io/en/stable/>`_: documentation for the
   IPython kernel.
 
-* `ipyparallel Documentation <http://ipyparallel.readthedocs.org/en/stable>`_
+* `ipyparallel Documentation <http://ipyparallel.readthedocs.io/en/stable>`_
   (formerly `IPython.Parallel` sub-package of IPython, now standalone).
 
 * `Main Documentation Site for Jupyter and IPython
-  <https://jupyter.readthedocs.org/en/latest>`_: umbrella site with
+  <https://jupyter.readthedocs.io/en/latest>`_: umbrella site with
   documentation for all the Jupyter projects, including links to the IPython
   docs.
 

--- a/install.rst
+++ b/install.rst
@@ -4,11 +4,11 @@ Installing IPython
 
 There are multiple ways of installing IPython. This page contains simplified installation
 instructions that should work for most users. Our official documentation
-contains `more detailed instructions <https://ipython.readthedocs.org/en/stable/install/install.html>`_
+contains `more detailed instructions <https://ipython.readthedocs.io/en/stable/install/install.html>`_
 for manual installation targeted at advanced users and developers.
 
 If you are looking for installation documentation for the notebook and/or qtconsole,
-those are now part of `Jupyter <https://jupyter.readthedocs.org/en/latest/install.html>`__.
+those are now part of `Jupyter <https://jupyter.readthedocs.io/en/latest/install.html>`__.
 
 I already have Python
 ---------------------


### PR DESCRIPTION
`readthedocs.org` is unavailable anymore because of deprecation, they've changed their TLD to `.io`