### PR TITLE
Update iPython website for 7.4 release

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -58,6 +58,8 @@ part of which is providing a Python kernel for Jupyter.
 Announcements
 =============
 
+- **IPython 7.4**: 
+
 - **IPython 7.3**: several bugfixes and minor improvements (February 18, 2019)
 
 - **IPython 7.2**: minor bugfixes, improvements, and new configuration options


### PR DESCRIPTION
This PR is to start the website release 7.4 updates by updating index.rst.

Participation including review, discussion, additional commits encouraged!!
news.rst still needs an update

@LucianaMarques 
@ppmfloss

Greetings from Los Angeles
