### PR TITLE
Update index.rst

### DIFF
--- a/index.rst
+++ b/index.rst
@@ -24,9 +24,9 @@ collection`_.  Our `notebook gallery`__ is an excellent way to see the many
 things you can do with IPython while learning about a variety of topics, from
 basic programming to advanced statistics or quantum mechanics.
 
-.. _official example collection: http://nbviewer.ipython.org/github/ipython/ipython/blob/master/examples/Index.ipynb
+.. _official example collection: https://nbviewer.org/github/ipython/ipython/blob/6.x/examples/IPython%20Kernel/Index.ipynb
 
-.. __: https://github.com/ipython/ipython/wiki/A-gallery-of-interesting-IPython-Notebooks
+.. __: https://github.com/jupyter/jupyter/wiki
 
 To learn more about IPython, you can download our :doc:`talks and presentations
 <presentation>`, or read


### PR DESCRIPTION
This small change corrects two links on the main page.

The first is a link to the official examples, which currently point to an outdated location.

The second is a link to the notebook gallery. The old link worked, but pointed to a github page which indicated that the resource had moved and pointed to a second page, which **also** indicated that the resource had moved and pointed to yet another page. I've replaced the old link with a direct link to the current location.

I note that these were brought up at https://github.com/ipython/ipython/issues/13766, and I'm fixing them here.