### PR TITLE
Update NumFOCUS donation links

### DIFF
--- a/_templates/donate_button.html
+++ b/_templates/donate_button.html
@@ -17,4 +17,4 @@
     color:#fff;
     text-decoration: none;
     z-index:1"
-  href="https://numfocus.salsalabs.org/donate-to-ipython/index.html">Donate Now</a>
+  href="https://numfocus.org/donate-to-ipython">Donate Now</a>

--- a/donate.rst
+++ b/donate.rst
@@ -32,7 +32,7 @@ resources.  Any amount helps!
         color:#fff;
         text-decoration: none;
         z-index:1"
-      href="https://numfocus.salsalabs.org/donate-to-ipython/index.html">Donate Now</a>
+      href="https://numfocus.org/donate-to-ipython">Donate Now</a>
 
 
 


### PR DESCRIPTION
Update non-working Salsa Labs donation page links to working page on numfocus.org.

I am a consultant working for NumFOCUS. Per #146, I have ensured that my membership in the NumFOCUS Github organization is public (https://github.com/orgs/numfocus/people?query=martey).