### PR TITLE
[Docs] Use extension:filetype mapping in sphinx configuration

### DIFF
--- a/conf.py
+++ b/conf.py
@@ -33,7 +33,7 @@ extensions = ['sphinx.ext.doctest',
 templates_path = ['_templates']
 
 # The suffix of source filenames.
-source_suffix = '.rst'
+source_suffix = {".rst": "restructuredtext"}
 
 # The encoding of source files.
 #source_encoding = 'utf-8-sig'


### PR DESCRIPTION
This is possible since sphinx 1.8, and avoid the message:

>  "Converting `source_suffix = '.rst'` to `source_suffix = {'.rst': 'restructuredtext'}`"

at docs build time. See https://www.sphinx-doc.org/en/master/usage/configuration.html#confval-source_suffix